### PR TITLE
Fixes #32 - Quandl now returns data oldest to newest.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: tidyquant
 Type: Package
 Title: Tidy Quantitative Financial Analysis
-Version: 0.5.0.9002
-Date: 2017-04-10
+Version: 0.5.0.9003
+Date: 2017-04-16
 Authors@R: c(
     person("Matt", "Dancho", email = "mdancho@business-science.io", role = c("aut", "cre")),
     person("Davis", "Vaughan", email = "dvaughan@business-science.io", role = c("aut"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,10 @@
-## tidyquant 0.5.0.9002
+## tidyquant 0.5.0.9003
 
 * Improvements
     * Added `pkgdown` integration.
 
 * Fixes:
+    * Quandl data returned newest to oldest. For consistency with other `tq_get()` data, it now returns oldest to newest.
     * Oanda only returns 180 days of FX and Metals data now. Updated the tests. Waiting for official `quantmod` hotfix release. The current fix is in a `quantmod` branch.
     * Fixed bug with `tq_portfolio()` where `weights = NULL` would not execute an equal weighting scheme.
     * Added error handling during dollar and percent conversion for get = "key.ratios" and get = "key.stats".

--- a/R/tq_get.R
+++ b/R/tq_get.R
@@ -758,7 +758,7 @@ tq_get_util_3 <- function(x, get, complete_cases, map, ...) {
 }
 
 # Util 4: Quandl -----
-tq_get_util_4 <- function(x, get, type = "raw",  meta = FALSE, complete_cases, map, ...) {
+tq_get_util_4 <- function(x, get, type = "raw",  meta = FALSE, order = "asc", complete_cases, map, ...) {
 
     # Check x
     if (!is.character(x)) {
@@ -770,15 +770,28 @@ tq_get_util_4 <- function(x, get, type = "raw",  meta = FALSE, complete_cases, m
         stringr::str_trim(side = "both")
 
     # Check type
-    if (type != "raw") type = "raw"
+    if (type != "raw") {
+        type = "raw"
+        warning("tidyquant only supports the 'raw' return type. Returning 'raw' data.", call. = FALSE)
+    }
 
     # Check meta
-    if (meta == TRUE) meta = FALSE
+    if (meta == TRUE) {
+        meta = FALSE
+        warning("tidyquant does not support Quandl meta data. Setting `meta == FALSE`.", call. = FALSE)
+    }
+
+    # Check order
+    if (order == "desc") {
+        order = "asc"
+        warning("For consistency, tidyquant does not return descending data. Returning ascending.", call. = FALSE)
+    }
 
     # Repurpose from and to as start_date and end_date
-    args <- list(code = x,
-                 type = type,
-                 meta = meta)
+    args <- list(code  = x,
+                 type  = type,
+                 meta  = meta,
+                 order = order)
     args <- append(args, list(...))
     if (!is.null(args$from)) args$start_date <- args$from
     if (!is.null(args$to)) args$end_date <- args$to

--- a/vignettes/TQ01-core-functions-in-tidyquant.Rmd
+++ b/vignettes/TQ01-core-functions-in-tidyquant.Rmd
@@ -274,7 +274,6 @@ c("WIKI/FB", "WIKI/AAPL") %>%
 
 The following time series options are available to be passed to the underlying `Quandl()` function:
 
-* `order` = "asc", "desc"
 * `start_date` (`from`) = "yyyy-mm-dd" | `end_date` (`to`) = "yyyy-mm-dd"
 * `column_index` = numeric column number (e.g. 1)
 * `rows` = numeric row number indicating first n rows (e.g. 100)


### PR DESCRIPTION
* Overrides quandl option to only return `order = "asc"`
* Update vignette by removing the option for the user to set `order = "asc"`
* `tq_get_util_4()` now has the argument `order = "asc"` so we can check if that arg has changed