### PR TITLE
Fix for the ggplot v3.1.0 colour issue #112

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: tidyquant
 Type: Package
 Title: Tidy Quantitative Financial Analysis
-Version: 0.5.6
-Date: 2019-04-22
+Version: 0.5.6.9000
+Date: 2019-05-05
 Authors@R: c(
     person("Matt", "Dancho", email = "mdancho@business-science.io", role = c("aut", "cre")),
     person("Davis", "Vaughan", email = "dvaughan@business-science.io", role = c("aut"))

--- a/R/geom_chart.R
+++ b/R/geom_chart.R
@@ -10,9 +10,9 @@
 #'
 #' @inheritParams geom_ma
 #' @inheritParams ggplot2::geom_linerange
-#' @param color_up,color_down Select colors to be applied based on price movement
-#' from open to close. If close >= open, `color_up` is used. Otherwise,
-#' `color_down` is used. The default is "darkblue" and "red", respectively.
+#' @param colour_up,colour_down Select colors to be applied based on price movement
+#' from open to close. If close >= open, `colour_up` is used. Otherwise,
+#' `colour_down` is used. The default is "darkblue" and "red", respectively.
 #' @param fill_up,fill_down Select fills to be applied based on price movement
 #' from open to close. If close >= open, `fill_up` is used. Otherwise,
 #' `fill_down` is used. The default is "darkblue" and "red", respectively.
@@ -72,7 +72,7 @@
 geom_barchart <- function(mapping = NULL, data = NULL, stat = "identity",
                              position = "identity", na.rm = TRUE, show.legend = NA,
                              inherit.aes = TRUE,
-                             color_up = "darkblue", color_down = "red",
+                             colour_up = "darkblue", colour_down = "red",
                              fill_up = "darkblue", fill_down = "red",
                              ...) {
 
@@ -82,21 +82,21 @@ geom_barchart <- function(mapping = NULL, data = NULL, stat = "identity",
         stat = StatLinerangeBC, geom = GeomLinerangeBC, data = data, mapping = mapping,
         position = position, show.legend = show.legend, inherit.aes = inherit.aes,
         params = list(na.rm = na.rm, fill_up = fill_up, fill_down = fill_down,
-                      color_up = color_up, color_down = color_down, ...)
+                      colour_up = colour_up, colour_down = colour_down, ...)
     )
 
     segment_left <- ggplot2::layer(
         stat = StatSegmentLeftBC, geom = GeomSegmentBC, data = data, mapping = mapping,
         position = position, show.legend = show.legend, inherit.aes = inherit.aes,
         params = list(na.rm = na.rm, fill_up = fill_up, fill_down = fill_down,
-                      color_up = color_up, color_down = color_down, ...)
+                      colour_up = colour_up, colour_down = colour_down, ...)
     )
 
     segment_right <- ggplot2::layer(
         stat = StatSegmentRightBC, geom = GeomSegmentBC, data = data, mapping = mapping,
         position = position, show.legend = show.legend, inherit.aes = inherit.aes,
         params = list(na.rm = na.rm, fill_up = fill_up, fill_down = fill_down,
-                      color_up = color_up, color_down = color_down, ...)
+                      colour_up = colour_up, colour_down = colour_down, ...)
     )
 
     list(linerange, segment_left, segment_right)
@@ -107,10 +107,10 @@ StatLinerangeBC <- ggplot2::ggproto("StatLinerangeBC", Stat,
 
                                     compute_group = function(data, scales, params,
                                                              fill_up, fill_down,
-                                                             color_up, color_down) {
+                                                             colour_up, colour_down) {
 
                                         data <-  data %>%
-                                            dplyr::mutate(color = ifelse(open < close, color_up, color_down))
+                                            dplyr::mutate(color = ifelse(open < close, colour_up, colour_down))
 
                                         tibble::tibble(x = data$x,
                                                        ymin = data$low,
@@ -124,10 +124,10 @@ StatSegmentLeftBC <- ggplot2::ggproto("StatSegmentLeftBC", Stat,
 
                                     compute_group = function(data, scales, params,
                                                              fill_up, fill_down,
-                                                             color_up, color_down) {
+                                                             colour_up, colour_down) {
 
                                         data <-  data %>%
-                                            dplyr::mutate(color = ifelse(open < close, color_up, color_down))
+                                            dplyr::mutate(color = ifelse(open < close, colour_up, colour_down))
 
                                         tibble::tibble(x    = data$x,
                                                        xend = data$x - 0.5,
@@ -143,10 +143,10 @@ StatSegmentRightBC <- ggplot2::ggproto("StatSegmentRightBC", Stat,
 
                                       compute_group = function(data, scales, params,
                                                                fill_up, fill_down,
-                                                               color_up, color_down) {
+                                                               colour_up, colour_down) {
 
                                           data <-  data %>%
-                                              dplyr::mutate(color = ifelse(open < close, color_up, color_down))
+                                              dplyr::mutate(color = ifelse(open < close, colour_up, colour_down))
 
                                           tibble::tibble(x    = data$x,
                                                          xend = data$x + 0.5,
@@ -176,7 +176,7 @@ GeomSegmentBC <- ggproto("GeomSegmentBC", GeomSegment,
 geom_candlestick <- function(mapping = NULL, data = NULL, stat = "identity",
                                 position = "identity", na.rm = TRUE, show.legend = NA,
                                 inherit.aes = TRUE,
-                                color_up = "darkblue", color_down = "red",
+                                colour_up = "darkblue", colour_down = "red",
                                 fill_up = "darkblue", fill_down = "red",
                                 ...) {
 
@@ -184,14 +184,14 @@ geom_candlestick <- function(mapping = NULL, data = NULL, stat = "identity",
         stat = StatLinerangeBC, geom = GeomLinerangeBC, data = data, mapping = mapping,
         position = position, show.legend = show.legend, inherit.aes = inherit.aes,
         params = list(na.rm = na.rm, fill_up = fill_up, fill_down = fill_down,
-                      color_up = color_up, color_down = color_down, ...)
+                      colour_up = colour_up, colour_down = colour_down, ...)
     )
 
     rect <- ggplot2::layer(
         stat = StatRectCS, geom = GeomRectCS, data = data, mapping = mapping,
         position = position, show.legend = show.legend, inherit.aes = inherit.aes,
         params = list(na.rm = na.rm, fill_up = fill_up, fill_down = fill_down,
-                      color_up = color_up, color_down = color_down, ...)
+                      colour_up = colour_up, colour_down = colour_down, ...)
     )
 
 
@@ -204,7 +204,7 @@ StatRectCS <- ggplot2::ggproto("StatRectCS", Stat,
 
                                 compute_group = function(data, scales, params,
                                                          fill_up, fill_down,
-                                                         color_up, color_down) {
+                                                         colour_up, colour_down) {
 
                                     data <-  data %>%
                                         dplyr::mutate(fill = ifelse(open < close, fill_up, fill_down),


### PR DESCRIPTION
Issue #112 can be fixed by renaming all American 'color' to British 'colour'. So I did that here and the candlesticks in tidyquant work now.