### PR TITLE
Restrict bad renamed column name matching to whole word OHLCV names

### DIFF
--- a/R/tq_mutate.R
+++ b/R/tq_mutate.R
@@ -339,7 +339,7 @@ detect_duplicates <- function(name_list) {
 # bad / restricted names are names that get selected unintetionally by OHLC functions
 replace_bad_names <- function(tib, fun_name) {
 
-    bad_names_regex <- "open|high|low|close|volume|adjusted|price"
+    bad_names_regex <- "^(open|high|low|close|volume|adjusted|price)$"
 
     name_list_tib <- colnames(tib)
     name_list_tib_lower <- stringr::str_to_lower(name_list_tib)


### PR DESCRIPTION
This is a stop gap solution to issue #137 until a more comprehensive solution is implemented. The small change basically restricts the bad name matching to whole-word only rather than the current more liberal partial matching. In this fix, only those column names that match the whole-word OHLCV names will be classified as bad names and replaced.