### PR TITLE
Update ggplot-geom_ma.R

### DIFF
--- a/R/ggplot-geom_ma.R
+++ b/R/ggplot-geom_ma.R
@@ -71,7 +71,7 @@
 #'    \item `colour`
 #'    \item `group`
 #'    \item `linetype`
-#'    \item `size`
+#'    \item `linewidth`
 #' }
 #'
 #'
@@ -207,7 +207,7 @@ StatMA_vol <- ggplot2::ggproto("StatSMA_vol", ggplot2::Stat,
 GeomMA <- ggplot2::ggproto("GeomMA", ggplot2::GeomLine,
                   default_aes = ggplot2::aes(colour = "darkblue",
                                     linetype = 2,
-                                    size = 0.5,
+                                    linewidth = 0.5,
                                     alpha = NA)
 )
 


### PR DESCRIPTION
Replace deprecated 'size' argument with 'linewidth'. Size aesthetic has been deprecated for use with lines as of ggplot2 3.4.0