### PR TITLE
Remove ggplot2 aes warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,16 +2,16 @@
 
 ## Breaking changes
 
-- tidyquant no longer loads lubridate. (#237, @olivroy)
+- tidyquant no longer loads lubridate. (@olivroy, #237)
   
   If you use tidyquant with tidyverse, there is no change for you.
 
-tidyquant no longer loads many packages.
+- tidyquant no longer loads many packages on load.
 
 ## Fixes
 
-- tidyquant startup messages mimics the tidyverse messages for clarity. (#163, #116)
-- Remove the dependency on tidyverse (#236, @olivroy)
+- tidyquant startup messages mimics the tidyverse messages for clarity. (@olivroy, #163, #116)
+- Remove the dependency on tidyverse (@olivroy, #236)
 - tidyquant no longer loads lubridate as tidyverse 2.0 now loads lubridate.
 - Changed the `size` argument to `linewidth` for ggplot2 3.4.0
 - Removed the last tidyr and dplyr deprecated functions.
@@ -19,6 +19,8 @@ tidyquant no longer loads many packages.
 - Move `Quandl`, `riingo`, and `alphavantager` to Suggests. tidyquant will not explicitly install those, but you can install them from CRAN.
 - Fixed CRAN package alias
 - FB to META change  in `FANG`
+- `geom_bbands()`, `geom_candlestick()`, and `geom_barchart()` no longer emit dropped aesthetics warnings. (@olivroy, #235)
+
 
 # tidyquant 1.0.7
 

--- a/R/ggplot-geom_bbands.R
+++ b/R/ggplot-geom_bbands.R
@@ -77,7 +77,7 @@
 #'     geom_line() +           # Plot stock price
 #'     geom_bbands(aes(high = high, low = low, close = close), ma_fun = SMA, n = 50) +
 #'     coord_x_date(xlim = c(as_date("2016-12-31") - dyears(1), as_date("2016-12-31")),
-#'                  ylim = c(75, 125))
+#'                  ylim = c(20, 35))
 #'
 #'
 #' # EMA
@@ -87,7 +87,7 @@
 #'    geom_bbands(aes(high = high, low = low, close = close),
 #'                   ma_fun = EMA, wilder = TRUE, ratio = NULL, n = 50) +
 #'    coord_x_date(xlim = c(as_date("2016-12-31") - dyears(1), as_date("2016-12-31")),
-#'                 ylim = c(75, 125))
+#'                 ylim = c(20, 35))
 #'
 #'
 #' # VWMA
@@ -97,7 +97,7 @@
 #'     geom_bbands(aes(high = high, low = low, close = close, volume = volume),
 #'                    ma_fun = VWMA, n = 50) +
 #'     coord_x_date(xlim = c(as_date("2016-12-31") - dyears(1), as_date("2016-12-31")),
-#'                 ylim = c(75, 125))
+#'                 ylim = c(20, 35))
 
 
 #' @rdname geom_bbands
@@ -166,7 +166,7 @@ geom_bbands_ <- function(mapping = NULL, data = NULL,
 
 StatBBandsRibbon <- ggplot2::ggproto("StatBBandsRibbon", ggplot2::Stat,
                             required_aes = c("x", "high", "low", "close"),
-
+                            dropped_aes = c("high", "low", "close", "y"),
                             compute_group = function(data, scales, params,
                                                      n = 10, ma_fun = SMA, sd = 2,
                                                      wilder = FALSE, ratio = NULL,
@@ -192,7 +192,7 @@ StatBBandsRibbon <- ggplot2::ggproto("StatBBandsRibbon", ggplot2::Stat,
 
 StatBBandsMA <- ggplot2::ggproto("StatBBandsMA", ggplot2::Stat,
                                  required_aes = c("x", "high", "low", "close"),
-
+                                 dropped_aes = c("high", "low", "close", "y"),
                                  compute_group = function(data, scales, params,
                                                           ma_fun = "SMA", n = 20, sd = 2,
                                                           wilder = FALSE, ratio = NULL,
@@ -217,7 +217,7 @@ StatBBandsMA <- ggplot2::ggproto("StatBBandsMA", ggplot2::Stat,
 
 StatBBandsRibbon_vol <- ggplot2::ggproto("StatBBandsRibbon", ggplot2::Stat,
                                          required_aes = c("x", "high", "low", "close", "volume"),
-
+                                         dropped_aes = c("high", "low", "close", "volume", "y"),
                                          compute_group = function(data, scales, params,
                                                                   ma_fun = "SMA", n = 10, sd = 2,
                                                                   wilder = FALSE, ratio = NULL,
@@ -244,7 +244,7 @@ StatBBandsRibbon_vol <- ggplot2::ggproto("StatBBandsRibbon", ggplot2::Stat,
 
 StatBBandsMA_vol <- ggplot2::ggproto("StatBBandsMA", ggplot2::Stat,
                                  required_aes = c("x", "high", "low", "close", "volume"),
-
+                                 dropped_aes = c("high", "low", "close", "volume", "y"),
                                  compute_group = function(data, scales, params,
                                                           n = 20, ma_fun = SMA, sd = 2,
                                                           wilder = FALSE, ratio = NULL,

--- a/R/ggplot-geom_chart.R
+++ b/R/ggplot-geom_chart.R
@@ -56,7 +56,7 @@
 #'     geom_barchart(aes(open = open, high = high, low = low, close = close)) +
 #'     geom_ma(color = "darkgreen") +
 #'     coord_x_date(xlim = c("2016-01-01", "2016-12-31"),
-#'                  ylim = c(75, 125))
+#'                  ylim = c(20, 30))
 #'
 #' # Candlestick Chart
 #' AAPL %>%
@@ -64,7 +64,7 @@
 #'     geom_candlestick(aes(open = open, high = high, low = low, close = close)) +
 #'     geom_ma(color = "darkgreen") +
 #'     coord_x_date(xlim = c("2016-01-01", "2016-12-31"),
-#'                  ylim = c(75, 125))
+#'                  ylim = c(20, 30))
 
 # Bar Chart -----
 
@@ -105,7 +105,7 @@ geom_barchart <- function(mapping = NULL, data = NULL, stat = "identity",
 
 StatLinerangeBC <- ggplot2::ggproto("StatLinerangeBC", ggplot2::Stat,
                                     required_aes = c("x", "open", "high", "low", "close"),
-
+                                    dropped_aes = c("open", "high", "low", "close", "y"),
                                     compute_group = function(data, scales, params,
                                                              fill_up, fill_down,
                                                              colour_up, colour_down) {
@@ -122,7 +122,7 @@ StatLinerangeBC <- ggplot2::ggproto("StatLinerangeBC", ggplot2::Stat,
 
 StatSegmentLeftBC <- ggplot2::ggproto("StatSegmentLeftBC", ggplot2::Stat,
                                     required_aes = c("x", "open", "high", "low", "close"),
-
+                                    dropped_aes = c("open", "high", "low", "close"),
                                     compute_group = function(data, scales, params,
                                                              fill_up, fill_down,
                                                              colour_up, colour_down) {
@@ -141,7 +141,7 @@ StatSegmentLeftBC <- ggplot2::ggproto("StatSegmentLeftBC", ggplot2::Stat,
 
 StatSegmentRightBC <- ggplot2::ggproto("StatSegmentRightBC", ggplot2::Stat,
                                       required_aes = c("x", "open", "high", "low", "close"),
-
+                                      dropped_aes = c("open", "high", "low", "close"),
                                       compute_group = function(data, scales, params,
                                                                fill_up, fill_down,
                                                                colour_up, colour_down) {
@@ -204,7 +204,7 @@ geom_candlestick <- function(mapping = NULL, data = NULL, stat = "identity",
 
 StatRectCS <- ggplot2::ggproto("StatRectCS", ggplot2::Stat,
                                 required_aes = c("x", "open", "high", "low", "close"),
-
+                                dropped_aes = c("open", "high", "low", "close", "x", "y"),
                                 compute_group = function(data, scales, params,
                                                          fill_up, fill_down,
                                                          colour_up, colour_down) {

--- a/R/ggplot-theme_tq.R
+++ b/R/ggplot-theme_tq.R
@@ -23,7 +23,7 @@
 #'                    ratio = NULL,
 #'                    n = 50) +
 #'        coord_x_date(xlim = c("2016-01-01", "2016-12-31"),
-#'                  ylim = c(75, 125)) +
+#'                  ylim = c(20, 35)) +
 #'        labs(title = "Apple BBands",
 #'             x = "Date",
 #'             y = "Price") +

--- a/man/geom_bbands.Rd
+++ b/man/geom_bbands.Rd
@@ -98,7 +98,7 @@ available including: SMA, EMA, WMA, DEMA, ZLEMA, VWMA, and EVWMA. The default is
 calculated; see notes.}
 
 \item{ratio}{A smoothing/decay ratio.  \code{ratio} overrides \code{wilder}
-in \code{EMA}, and provides additional smoothing in \code{VMA}.}
+in \code{EMA}.}
 
 \item{v}{The 'volume factor' (a number in [0,1]).  See Notes.}
 
@@ -172,7 +172,7 @@ AAPL \%>\%
     geom_line() +           # Plot stock price
     geom_bbands(aes(high = high, low = low, close = close), ma_fun = SMA, n = 50) +
     coord_x_date(xlim = c(as_date("2016-12-31") - dyears(1), as_date("2016-12-31")),
-                 ylim = c(75, 125))
+                 ylim = c(20, 35))
 
 
 # EMA
@@ -182,7 +182,7 @@ AAPL \%>\%
    geom_bbands(aes(high = high, low = low, close = close),
                   ma_fun = EMA, wilder = TRUE, ratio = NULL, n = 50) +
    coord_x_date(xlim = c(as_date("2016-12-31") - dyears(1), as_date("2016-12-31")),
-                ylim = c(75, 125))
+                ylim = c(20, 35))
 
 
 # VWMA
@@ -192,7 +192,7 @@ AAPL \%>\%
     geom_bbands(aes(high = high, low = low, close = close, volume = volume),
                    ma_fun = VWMA, n = 50) +
     coord_x_date(xlim = c(as_date("2016-12-31") - dyears(1), as_date("2016-12-31")),
-                ylim = c(75, 125))
+                ylim = c(20, 35))
 }
 \seealso{
 See individual modeling functions for underlying parameters:

--- a/man/geom_chart.Rd
+++ b/man/geom_chart.Rd
@@ -131,7 +131,7 @@ AAPL \%>\%
     geom_barchart(aes(open = open, high = high, low = low, close = close)) +
     geom_ma(color = "darkgreen") +
     coord_x_date(xlim = c("2016-01-01", "2016-12-31"),
-                 ylim = c(75, 125))
+                 ylim = c(20, 30))
 
 # Candlestick Chart
 AAPL \%>\%
@@ -139,7 +139,7 @@ AAPL \%>\%
     geom_candlestick(aes(open = open, high = high, low = low, close = close)) +
     geom_ma(color = "darkgreen") +
     coord_x_date(xlim = c("2016-01-01", "2016-12-31"),
-                 ylim = c(75, 125))
+                 ylim = c(20, 30))
 }
 \seealso{
 See individual modeling functions for underlying parameters:

--- a/man/geom_ma.Rd
+++ b/man/geom_ma.Rd
@@ -86,7 +86,7 @@ available including: SMA, EMA, WMA, DEMA, ZLEMA, VWMA, and EVWMA. The default is
 calculated; see notes.}
 
 \item{ratio}{A smoothing/decay ratio.  \code{ratio} overrides \code{wilder}
-in \code{EMA}, and provides additional smoothing in \code{VMA}.}
+in \code{EMA}.}
 
 \item{v}{The 'volume factor' (a number in [0,1]).  See Notes.}
 

--- a/man/theme_tq.Rd
+++ b/man/theme_tq.Rd
@@ -37,7 +37,7 @@ AAPL \%>\% ggplot(aes(x = date, y = close)) +
                    ratio = NULL,
                    n = 50) +
        coord_x_date(xlim = c("2016-01-01", "2016-12-31"),
-                 ylim = c(75, 125)) +
+                 ylim = c(20, 35)) +
        labs(title = "Apple BBands",
             x = "Date",
             y = "Price") +


### PR DESCRIPTION
Fix #235.

Approach:

look at whatever compute groups return, and add anything else to dropped aesthetics.

I also changed the limits since the current limits show an empty plot. https://business-science.github.io/tidyquant/reference/geom_bbands.html#ref-examples